### PR TITLE
fix: Pool size must be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 New configuration to access the database:
 
-* `EDC_SERVER_DB_CONNECTION_POOL_SIZE`
-  * The property controls the maximum size that the pool is allowed to reach, including both idle and in-use connections. Basically this value will determine the maximum number of actual connections to the database backend.
-  * Defaults to 3
+- `EDC_SERVER_DB_CONNECTION_POOL_SIZE`
+  - The property controls the maximum size that the pool is allowed to reach, including both idle and in-use connections. Basically this value will determine the maximum number of actual connections to the database backend.
+  - Defaults to `3`
 
 #### Compatible Versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 ### Deployment Migration Notes
 
+New configuration to access the database:
+
+* `EDC_SERVER_DB_CONNECTION_POOL_SIZE`
+  * The property controls the maximum size that the pool is allowed to reach, including both idle and in-use connections. Basically this value will determine the maximum number of actual connections to the database backend.
+  * Defaults to 3
+
 #### Compatible Versions
 
 - Connector Backend Docker Images:
@@ -41,7 +47,7 @@ MDS 2.2 intermediate release
 
 - API Wrapper UI API: Data sources are now well-typed.
 - The Broker has been removed in favor of the Authority Portal:
-  - A new Deployment Unit, the ["Data Catalog Crawler"](extensions/catalog-crawler/README.md), has been added. 
+  - A new Deployment Unit, the ["Data Catalog Crawler"](extensions/catalog-crawler/README.md), has been added.
   - Each "Data Catalog Crawler" connects to an existing Authority Portal Deployment's DB.
   - Each "Data Catalog Crawler" is responsible for crawling exactly one environment.
   - The Data Catalog functionality of the Broker has been integrated into the Authority Portal.
@@ -63,8 +69,8 @@ MDS 2.2 intermediate release
 - Connector:
   - The database migration system has been moved from multiple migration history tables to a single one.
 - Broker:
-  - The broker has been removed. For Authority Portal users, please check out the new 
-    [Data Catalog Crawler Productive Deployment Guide](docs/deployment-guide/goals/catalog-crawler-production/README.md). 
+  - The broker has been removed. For Authority Portal users, please check out the new
+    [Data Catalog Crawler Productive Deployment Guide](docs/deployment-guide/goals/catalog-crawler-production/README.md).
   - Any previous broker deployment's database is not required anymore.
   - Please care that only some environment variables look similar. It is recommended to create fresh deployments.
 

--- a/extensions/database-direct-access/src/main/java/de/sovity/edc/extension/db/directaccess/DatabaseDirectAccessExtension.java
+++ b/extensions/database-direct-access/src/main/java/de/sovity/edc/extension/db/directaccess/DatabaseDirectAccessExtension.java
@@ -50,12 +50,6 @@ public class DatabaseDirectAccessExtension implements ServiceExtension {
     @Setting(defaultValue = "3")
     public static final String EDC_SERVER_DB_CONNECTION_POOL_SIZE = "edc.server.db.connection.pool.size";
 
-    /**
-     * Sets the connection timeout for the datasource in milliseconds.
-     */
-    @Setting(defaultValue = "5000")
-    public static final String EDC_SERVER_DB_CONNECTION_TIMEOUT_IN_MS = "edc.server.db.connection.timeout.in.ms";
-
 
     @Override
     public String name() {
@@ -75,11 +69,11 @@ public class DatabaseDirectAccessExtension implements ServiceExtension {
         hikariConfig.setUsername(config.getString(EDC_DATASOURCE_JDBC_USER));
         hikariConfig.setPassword(config.getString(EDC_DATASOURCE_JDBC_PASSWORD));
         hikariConfig.setMinimumIdle(1);
-        hikariConfig.setMaximumPoolSize(config.getInteger(EDC_SERVER_DB_CONNECTION_POOL_SIZE));
+        hikariConfig.setMaximumPoolSize(config.getInteger(EDC_SERVER_DB_CONNECTION_POOL_SIZE, 3));
         hikariConfig.setIdleTimeout(30000);
         hikariConfig.setPoolName("direct-database-access");
         hikariConfig.setMaxLifetime(50000);
-        hikariConfig.setConnectionTimeout(config.getInteger(EDC_SERVER_DB_CONNECTION_TIMEOUT_IN_MS));
+        hikariConfig.setConnectionTimeout(1000);
 
         val dda = new DslContextFactory(new HikariDataSource(hikariConfig));
 


### PR DESCRIPTION
Fix a problem when starting the EDC without the max connection pool size property.

The timeout property doesn't need to be exposed to sysadmins.

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [x] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [x] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [ ] I have updated the Community Edition [Postman-Collection](https://github.com/sovity/edc-ce/blob/main/docs/api/postman_collection.json) if I changed existing APIs or added new APIs (e.g. for Management-API or API-Wrapper)
- [x] I have performed a **self-review**
```
