### PR TITLE
fix: Remove duplicate database indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch Changes
 
+- Remove duplicate database indices if they exist
+
 ### Deployment Migration Notes
 
 #### Compatible Versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ please see [changelog_updates.md](docs/dev/changelog_updates.md).
 
 #### Patch Changes
 
-- Remove duplicate database indices if they exist
+- Improve database performance by removing duplicate indexes
 
 ### Deployment Migration Notes
 

--- a/extensions/postgres-flyway/src/main/resources/db/migration/V12__DROP_duplicate_indices.sql
+++ b/extensions/postgres-flyway/src/main/resources/db/migration/V12__DROP_duplicate_indices.sql
@@ -1,0 +1,30 @@
+--
+--  Copyright (c) 2024 sovity GmbH
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       sovity GmbH - Improve database performance by removing duplicate indices
+--
+
+-- Drop the non _pk index for edc_contract_agreement if it exists.
+DROP INDEX IF EXISTS contract_agreement_id_uindex;
+
+-- Drop the non _pk index for edc_contract_negotiation if it exists.
+DROP INDEX IF EXISTS contract_negotiation_id_uindex;
+
+-- Drop the non _pk index for edc_data_request if it exists.
+DROP INDEX IF EXISTS data_request_id_uindex;
+
+-- Drop the non _pk index for edc_lease if it exists.
+DROP INDEX IF EXISTS lease_lease_id_uindex;
+
+-- Drop the non _pk index for edc_policydefinitions if it exists.
+DROP INDEX IF EXISTS edc_policydefinitions_id_uindex;
+
+-- Drop the non _pk index for edc_transfer_process if it exists.
+DROP INDEX IF EXISTS transfer_process_id_uindex;

--- a/extensions/postgres-flyway/src/main/resources/db/migration/V12__DROP_duplicate_indices.sql
+++ b/extensions/postgres-flyway/src/main/resources/db/migration/V12__DROP_duplicate_indices.sql
@@ -11,20 +11,11 @@
 --       sovity GmbH - Improve database performance by removing duplicate indices
 --
 
--- Drop the non _pk index for edc_contract_agreement if it exists.
+-- Drop the duplicate indexes if they exist for improved resource usage.
 DROP INDEX IF EXISTS contract_agreement_id_uindex;
-
--- Drop the non _pk index for edc_contract_negotiation if it exists.
 DROP INDEX IF EXISTS contract_negotiation_id_uindex;
-
--- Drop the non _pk index for edc_data_request if it exists.
 DROP INDEX IF EXISTS data_request_id_uindex;
-
--- Drop the non _pk index for edc_lease if it exists.
 DROP INDEX IF EXISTS lease_lease_id_uindex;
-
--- Drop the non _pk index for edc_policydefinitions if it exists.
 DROP INDEX IF EXISTS edc_policydefinitions_id_uindex;
-
--- Drop the non _pk index for edc_transfer_process if it exists.
 DROP INDEX IF EXISTS transfer_process_id_uindex;
+


### PR DESCRIPTION
_What issues does this PR close?_

These indices are 100% the same as the PK ones and only cause overhead, hence the removal.

```[tasklist]
### Checklist
- [X] The PR title is short and expressive.
- [X] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [X] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [X] I have updated the Community Edition [Postman-Collection](https://github.com/sovity/edc-ce/blob/main/docs/api/postman_collection.json) if I changed existing APIs or added new APIs (e.g. for Management-API or API-Wrapper)
- [X] I have performed a **self-review**
```
