### PR TITLE
fix(postman): update collection to reflect recent API changes

### DIFF
--- a/docs/api/postman_collection.json
+++ b/docs/api/postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "3e0d6241-260c-42d3-81a1-3e3d4e9497e1",
+		"_postman_id": "213f5ff6-e5c6-41bb-9202-8e6cf60fec0c",
 		"name": "sovity EDC Community Edition Copy",
 		"description": "This is the official postman collection for the sovity EDC Community Edition.\n\nThe Management-API is based on core-edc v0.2.1.\n\nsovity EDC Community Edition: [https://github.com/sovity/edc-ce](https://github.com/sovity/edc-ce)\n\nLicense: [https://github.com/sovity/edc-ce/blob/main/LICENSE](https://github.com/sovity/edc-ce/blob/main/LICENSE)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -212,7 +212,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{PROVIDER_EDC_MANAGEMENT_URL}}/wrapper/ui/pages/asset-page/assets/{{ASSET_ID}}/metadata",
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_URL}}/wrapper/ui/pages/asset-page/assets/{{ASSET_ID}}",
 									"host": [
 										"{{PROVIDER_EDC_MANAGEMENT_URL}}"
 									],
@@ -222,8 +222,7 @@
 										"pages",
 										"asset-page",
 										"assets",
-										"{{ASSET_ID}}",
-										"metadata"
+										"{{ASSET_ID}}"
 									],
 									"query": [
 										{


### PR DESCRIPTION
_What issues does this PR close?_

Postman-Collection contains outdated API-Wrapper Assets PUT call.

Before v9.0.0 **with** /metadata for PUT:
https://github.com/sovity/edc-ce/blob/f91a9ce14a30b0e947c0aa988db84d615a944dae/extensions/wrapper/wrapper-api/src/main/java/de/sovity/edc/ext/wrapper/api/ui/UiResource.java#L73

Including and after v9.0.0 **without** /metadata for PUT:
https://github.com/sovity/edc-ce/blob/329bfc4d4d15665a6228ce1c2fe7c29e70c81f5e/extensions/wrapper/wrapper-api/src/main/java/de/sovity/edc/ext/wrapper/api/ui/UiResource.java#L76

Release v9.0.0: https://github.com/sovity/edc-ce/releases/tag/v9.0.0

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [ ] ~~I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.~~
- [ ] ~~I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.~~
- [x] I have updated the Community Edition [Postman-Collection](https://github.com/sovity/edc-ce/blob/main/docs/api/postman_collection.json) if I changed existing APIs or added new APIs (e.g. for Management-API or API-Wrapper)
- [x] I have performed a **self-review**
```
