### PR TITLE
fix(trivy): prevent rate-limit issues

### DIFF
--- a/.github/workflows/license_scan.yml
+++ b/.github/workflows/license_scan.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run license scanner
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "rootfs"
           scan-ref: "."
@@ -35,9 +35,9 @@ jobs:
       - name: npm install (typescript-client-example)
         run: cd extensions/wrapper/clients/typescript-client-example && npm clean-install
       - name: Run license scanner
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "repo"
           scan-ref: "."

--- a/.github/workflows/license_scan.yml
+++ b/.github/workflows/license_scan.yml
@@ -16,6 +16,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.26.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "rootfs"
           scan-ref: "."
@@ -38,6 +39,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.26.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "repo"
           scan-ref: "."

--- a/.github/workflows/license_scan.yml
+++ b/.github/workflows/license_scan.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scan-ref: "."
@@ -38,8 +39,9 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "repo"
           scan-ref: "."

--- a/.github/workflows/license_scan.yml
+++ b/.github/workflows/license_scan.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "rootfs"
           scan-ref: "."
@@ -38,8 +38,8 @@ jobs:
       - name: Run license scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "repo"
           scan-ref: "."

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -20,6 +20,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.26.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "fs"
           exit-code: "1"

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "fs"
           exit-code: "1"

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -19,8 +19,9 @@ jobs:
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "fs"
           exit-code: "1"

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -17,9 +17,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "fs"
           exit-code: "1"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -15,6 +15,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.26.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "rootfs"
           scanners: "vuln,misconfig"
@@ -33,6 +34,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.26.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "repo"
           scanners: "vuln,misconfig"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -14,8 +14,9 @@ jobs:
       - name: Run static analysis (rootfs)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "rootfs"
           scanners: "vuln,misconfig"
@@ -33,8 +34,9 @@ jobs:
       - name: Run static analysis (repo)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "repo"
           scanners: "vuln,misconfig"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Run static analysis (rootfs)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "rootfs"
           scanners: "vuln,misconfig"
@@ -33,8 +33,8 @@ jobs:
       - name: Run static analysis (repo)
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: "repo"
           scanners: "vuln,misconfig"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run static analysis (rootfs)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "rootfs"
           scanners: "vuln,misconfig"
@@ -30,9 +30,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run static analysis (repo)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: "repo"
           scanners: "vuln,misconfig"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Run static analysis
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          #try default GitHub DBs, if failing, use AWS mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: 'fs'
           security-checks: 'vuln,secret,config'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run static analysis
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: 'fs'
           security-checks: 'vuln,secret,config'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Run static analysis
         uses: aquasecurity/trivy-action@0.26.0
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db #try default GitHub db, if failing, use aws mirror instead (https://github.com/aquasecurity/trivy-action/issues/389)
         with:
           scan-type: 'fs'
           security-checks: 'vuln,secret,config'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,6 +18,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.26.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db #mirror because of https://github.com/aquasecurity/trivy-action/issues/389
         with:
           scan-type: 'fs'
           security-checks: 'vuln,secret,config'


### PR DESCRIPTION
_What issues does this PR close?_
Trivy can run into db-download-rate limits using GitHub as DB host. A newer version now introduced db-caching and additionally a mirror of the original Trivy DBs is used instead of GitHub if running into GitHub rate limits.

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [ ] I have updated the CHANGELOG.md. See [changelog_update.md](https://github.com/sovity/authority-portal/tree/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [ ] I have updated the Community Edition [Postman-Collection](https://github.com/sovity/edc-ce/blob/main/docs/api/postman_collection.json) if I changed existing APIs or added new APIs (e.g. for Management-API or API-Wrapper)
- [x] I have performed a **self-review**
```
