### PR TITLE
docs: update postman link of old docu to older collection

### DIFF
--- a/docs/Backend/Postman/setting-up-postman.md
+++ b/docs/Backend/Postman/setting-up-postman.md
@@ -26,7 +26,7 @@ Once Postman is installed and running, set up the API environment as follows:
 - Follow the prompts to complete the import process
 
 {% hint style="info" %} 
-Direct Link to Postman collection: <a href="https://raw.githubusercontent.com/sovity/edc-ce/main/docs/api/postman_collection.json">https://raw.githubusercontent.com/sovity/edc-ce/main/docs/api/postman_collection.json</a>
+Direct Link to Postman collection: <a href="https://github.com/sovity/edc-ce/blob/gitbook/docs/api/postman_collection.json">https://github.com/sovity/edc-ce/blob/gitbook/docs/api/postman_collection.json</a>
 {% endhint %}
 
 

--- a/docs/Backend/Postman/setting-up-postman.md
+++ b/docs/Backend/Postman/setting-up-postman.md
@@ -26,7 +26,7 @@ Once Postman is installed and running, set up the API environment as follows:
 - Follow the prompts to complete the import process
 
 {% hint style="info" %} 
-Direct Link to Postman collection: <a href="https://github.com/sovity/edc-ce/blob/gitbook/docs/api/postman_collection.json">https://github.com/sovity/edc-ce/blob/gitbook/docs/api/postman_collection.json</a>
+Direct Link to Postman collection: <a href="https://raw.githubusercontent.com/sovity/edc-ce/refs/heads/gitbook/docs/api/postman_collection.json">https://raw.githubusercontent.com/sovity/edc-ce/refs/heads/gitbook/docs/api/postman_collection.json</a>
 {% endhint %}
 
 


### PR DESCRIPTION
### Checklist
Older core-edc 0.2.1-based EDC also requires an older collection.

- [x] The PR title is short and expressive.
- [ ] I have updated the CHANGELOG.md. Hints on formulation: Important information first, details second.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [ ] I have updated the Community Edition [Postman-Collection](https://github.com/sovity/edc-ce/blob/main/docs/api/postman_collection.json) if I changed existing APIs or added new APIs (e.g. for Management-API or API-Wrapper)
- [x] I have performed a self-review
- [x] I understand that my contributions will be contributed under the Contributor License Agreement (CLA) which has to be agreed to on your first contribution.
- [ ] I have added / adjusted Apache 2.0 license headers to files *.ts, *.kts, *.kt, *.java and marked anything else of relevance in the NOTICE file.
